### PR TITLE
Bump the npm_and_yarn group across 1 directory with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18",
         "react-device-detect": "^2.2.3",
         "react-dom": "^18",
-        "universal-cookie": "^6.1.1"
+        "universal-cookie": "^7.2.1"
       },
       "devDependencies": {
         "@mep-agency/next-iubenda": "^1.0.0-alpha4",
@@ -1146,9 +1146,9 @@
       "dev": true
     },
     "node_modules/@types/cookie": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
-      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1884,9 +1884,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5106,12 +5106,12 @@
       "dev": true
     },
     "node_modules/universal-cookie": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.1.tgz",
-      "integrity": "sha512-33S9x3CpdUnnjwTNs2Fgc41WGve2tdLtvaK2kPSbZRc5pGpz2vQFbRWMxlATsxNNe/Cy8SzmnmbuBM85jpZPtA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.1.tgz",
+      "integrity": "sha512-GEKneQ0sz8qbobkYM5s9elAx6l7GQDNVl3Siqmc7bt/YccyyXWDPn+fht3J1qMcaLwPrzkty3i+dNfPGP2/9hA==",
       "dependencies": {
-        "@types/cookie": "^0.5.1",
-        "cookie": "^0.5.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^18",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18",
-    "universal-cookie": "^6.1.1"
+    "universal-cookie": "^7.2.1"
   },
   "devDependencies": {
     "@mep-agency/next-iubenda": "^1.0.0-alpha4",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 2 updates in the / directory: [cookie](https://github.com/jshttp/cookie) and [universal-cookie](https://github.com/bendotcodes/cookies).


Updates `cookie` from 0.5.0 to 0.7.2
- [Release notes](https://github.com/jshttp/cookie/releases)
- [Commits](https://github.com/jshttp/cookie/compare/v0.5.0...v0.7.2)

Updates `universal-cookie` from 6.1.1 to 7.2.1
- [Release notes](https://github.com/bendotcodes/cookies/releases)
- [Changelog](https://github.com/bendotcodes/cookies/blob/main/LEGACY-CHANGELOG.md)
- [Commits](https://github.com/bendotcodes/cookies/compare/v6.1.1...v7.2.1)

---
updated-dependencies:
- dependency-name: cookie dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: universal-cookie dependency-type: direct:production dependency-group: npm_and_yarn ...